### PR TITLE
Added translation for german language

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ available in ad-gallery :
 
 Internationalization
 -------------------------
-Currently plugin supports 2 languages.
+Currently plugin supports 9 languages.
 
 * en
 * fr
+* de
 * ru Russian
 * el Greek, Modern (1453-)
 * sr Serbian

--- a/lang/de.js
+++ b/lang/de.js
@@ -1,0 +1,41 @@
+﻿/*
+Copyright (c) 2003-2013, Cricri042. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+Targeted for "ad-gallery" JavaScript : http://adgallery.codeplex.com/
+And "Fancybox" : http://fancyapps.com/fancybox/
+*/
+CKEDITOR.plugins.setLang( 'slideshow', 'de', {
+	toolbar	: 'SlideShow',
+	dialogTitle : 'SlideShow Eigenschaften',
+	fakeObject : 'SlideShow',
+	imgList : 'Bilder',
+	imgAdd : 'Bilder hinzufügen',
+	imgTitle : 'Titel',
+	imgDelete : 'Löschen',
+	imgEdit : 'Bearbeiten',
+    validModif : 'Speichern',
+	previewMode : 'Vorschau',
+	imgDesc : 'Kurzbeschreibung',
+	editSlideShow : 'Slideshow bearbeiten',
+	picturesList : "Liste der Bilder :",
+	insertSlideShow : 'SlideShow einfügen',
+	showThumbs : 'Vorschaubilder anzeigen',
+	showTitle : 'Titel anzeigen',
+	showControls : "Start / Stop Steuerung anbieten",
+	labelStart : "Start",
+	labelStop : "Stop",
+	arrowUp : "\u2191",
+	arrowDown : "\u2193",
+	displayTime : 'Anzeigedauer (Sec.)',
+	transitionTime : 'Übergangsdauer (mSec.)',
+	autoStart : 'Autostart',
+	pictHeight : 'Höhe (px)',
+	pictWidth : 'Breite (px)',
+	openOnClick : 'Per Klick öffnen',
+	transition : 'Übergangstyp',
+	tr1 : 'Keine',
+	tr2 : 'Größe verändern',
+	tr3 : 'Vertikal verschieben',
+	tr4 : 'Horizontal verschieben',
+	tr5 : 'Ausblenden',
+});

--- a/plugin.js
+++ b/plugin.js
@@ -31,7 +31,7 @@ CKEDITOR.plugins.add( 'slideshow', {
 	// Translations, available at the end of this file, without extra requests
 	//lang : [ 'en', 'fr' ],
 	requires: 'contextmenu,fakeobjects',
-	lang: 'en,fr,ru,el,sr,sr-latn,pt,pt-br',
+	lang: 'en,de,fr,ru,el,sr,sr-latn,pt,pt-br',
 
 	getSlideShowDialogCss : function()
 	{


### PR DESCRIPTION
Translated lang/en.js to lang/de.js
I am not shure about naming convention, but usually german packs are labeled 'de'.